### PR TITLE
Add installation instruction and modify Lesson3/main.jl with current versin of MCMC.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,7 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
-# ignore project too for now
-Project.toml
+
 
 # user added
 tmp*.jl

--- a/Lesson0/Installation.jl
+++ b/Lesson0/Installation.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.5
+# v0.20.6
 
 using Markdown
 using InteractiveUtils
@@ -7,7 +7,15 @@ using InteractiveUtils
 # ╔═╡ e97182aa-00ee-11f0-23f8-15d4527ad4d6
 md"""
 # Install Julia
-Julia has its own installer called `juliaup`, all you have to do is follow the instructions [here](https://julialang.org/downloads/).
+Julia has its own installer called `juliaup`.
+
+For Unix systems (MacOs and Linux) you can install it running the following command:
+```bash
+curl -fsSL https://install.julialang.org | sh
+```
+For Windows systems it can be installed from the Microsoft Store [here](https://www.microsoft.com/store/apps/9NJNWW8PVKMN).
+
+juliaup will automatically install the latest stable julia version.
 """
 
 # ╔═╡ f4e57cc3-29ca-466d-90d0-2fc45784a30d

--- a/Lesson3/analyze.jl
+++ b/Lesson3/analyze.jl
@@ -1,0 +1,20 @@
+function get_res(; path::String=".")
+    dir = readdir(path)
+    files = filter(x -> (isfile(x) && endswith(x, ".csv")), dir)
+    return files
+end
+
+files = get_res()
+using CSV
+using Statistics
+
+all_data = Float64[]
+
+# Loop through each file and append its data to `all_data`
+for file in files
+    data = CSV.File(file, header=false)["Column1"]
+    append!(all_data, data)
+end
+
+# Perform calculations on the combined data
+@show 4 * mean(all_data) 4 * std(all_data) / sqrt(length(all_data))

--- a/Lesson3/main.jl
+++ b/Lesson3/main.jl
@@ -10,12 +10,14 @@ function main(file::HDF5.File)
 
     acquire(semaphore)
 
-    pi_mcmc = PiMCMC(state=[0.0, 0.0], checkpoint_file=file)
-
+    pi_mcmc = PiMCMC([0.0, 0.0], checkpoint_file=file)
     Base.with_logger(mcmc_logger(id(pi_mcmc), 1_000)) do
-        run!(pi_mcmc, 1_000_000)
+        try
+            run!(pi_mcmc, 1_000_000)
+        finally
+            close(save_file(pi_mcmc))
+        end
     end
-
     release(semaphore)
 end
 

--- a/Lesson3/main.jl
+++ b/Lesson3/main.jl
@@ -1,0 +1,25 @@
+using MCMC, HDF5
+
+import Base: Semaphore, acquire, release
+
+const semaphore = Semaphore(Threads.nthreads())
+
+MCMC.should_save(::PiMCMC, i::Int) = i % 1_000 == 0
+
+function main(file::HDF5.File)
+
+    acquire(semaphore)
+
+    pi_mcmc = PiMCMC(state=[0.0, 0.0], checkpoint_file=file)
+
+    Base.with_logger(mcmc_logger(id(pi_mcmc), 1_000)) do
+        run!(pi_mcmc, 1_000_000)
+    end
+
+    release(semaphore)
+end
+
+h5open("checkpoint.h5", "w") do file
+    tasks = [Threads.@spawn main($file) for _ in 1:10]
+    wait.(tasks)
+end

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,12 @@
+[deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+FilePathsBase = "48062228-2e41-5def-b9a4-89aafe57970f"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
+MCMC = "9b599511-0acd-47dc-8066-53df86f12503"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
+StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"

--- a/Project.toml
+++ b/Project.toml
@@ -10,3 +10,7 @@ MCMC = "9b599511-0acd-47dc-8066-53df86f12503"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+
+[compat]
+Pluto = "0.20.6"
+julia = "1.11.5"


### PR DESCRIPTION
This pull request includes updates to installation instructions in `Lesson0/Installation.jl` and improvements to the `main` function in `Lesson3/main.jl`. The most important changes include adding Unix-specific installation steps for Julia, updating the version of Pluto.jl, and ensuring proper resource cleanup in the `PiMCMC` workflow.

### Installation updates:
* [`Lesson0/Installation.jl`](diffhunk://#diff-b26ddcac81b3c875b05262f5c9069a3b4b33134acd24a82f859646eabd445a18L2-R18): Updated Julia installation instructions to include Unix-specific installation steps using a `curl` command and clarified Windows installation via the Microsoft Store. Also updated the Pluto.jl version from `v0.20.5` to `v0.20.6`.

### Workflow improvements:
* [`Lesson3/main.jl`](diffhunk://#diff-17a677f2539a8b7e9a377f1fab6343d93cfe4b4eeaaf37155c40ba8f34736657L13-L18): Refactored the `PiMCMC` initialization by removing the `state` keyword argument and passing the state as a positional argument. Added a `try-finally` block to ensure the checkpoint file is properly closed after the `run!` function completes.